### PR TITLE
fix: fix ai-competition page layout

### DIFF
--- a/src/components/TwoColumnLayout/index.tsx
+++ b/src/components/TwoColumnLayout/index.tsx
@@ -8,10 +8,12 @@ export interface TwoColumnLayoutProps {
 const TwoColumnLayout = ({ leftColumn, rightColumn }: TwoColumnLayoutProps) => {
   return (
     <div className="flex flex-col md:flex-row p-4 md:p-16 w-full md:w-4/5 justify-center items-stretch">
-      <div className="flex-1 md:w-1/2 mb-4 md:mb-0 order-1 md:order-2">
+      <div className="flex-1 md:w-1/2 mb-4 md:mb-0 order-1 md:order-2 md:ml-5 ">
         {rightColumn}
       </div>
-      <div className="flex-1 md:w-1/2 order-2 md:order-1">{leftColumn}</div>
+      <div className="flex-1 md:w-1/2 order-2 md:order-1  md:mr-5">
+        {leftColumn}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- Adjusts the margin of the TwoColumnLayout component on the AI-Competition page to prevent elements from being too close together on the iPad Air screen, ensuring a more aesthetically pleasing layout